### PR TITLE
Fix gradient of funnel

### DIFF
--- a/main/MCMC.js
+++ b/main/MCMC.js
@@ -154,7 +154,7 @@ MCMC.targets["funnel"] = {
       s1 = Math.exp(x[0] / 2);
     return matrix([
       [dfdx(x[1], m1, Math.exp(x[0] / 2))],
-      [dfds(x[0], m0, s0) + 0.5 * Math.exp(x[0] / 2) * dfds(x[1], m1, Math.exp(x[0] / 2))],
+      [dfdx(x[0], m0, s0) + 0.5 * Math.exp(x[0] / 2) * dfds(x[1], m1, Math.exp(x[0] / 2))],
     ]);
   },
 };


### PR DESCRIPTION
I think there's a small bug in funnel's gradient implementation.
With the fix, it now agrees with numerical differentiation. Came across this while building a simple uncertainty quantification benchmark inspired by this distribution.
Awesome project by the way, thanks for publishing it :)